### PR TITLE
fix auto-delete queues when consumers are deleted

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -78,7 +78,7 @@ export class RabbitMqConsumer {
   protected getDLSettings(): amqp.Options.AssertQueue {
     return {
       durable: true,
-      autoDelete: false
+      autoDelete: true
     }
   }
 }

--- a/src/producer.ts
+++ b/src/producer.ts
@@ -34,7 +34,7 @@ export class RabbitMqProducer {
   protected getQueueSettings(deadletterExchangeName: string): amqp.Options.AssertQueue {
     return {
       durable: true,
-      autoDelete: false,
+      autoDelete: true,
       arguments: {
         'x-dead-letter-exchange': deadletterExchangeName
       }

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -47,9 +47,8 @@ export class RabbitMqPublisher {
 
     protected getSettings(): amqp.Options.AssertQueue {
         return {
+            autoDelete: true,
             durable: false,
         }
     }
 }
-
-

--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -71,7 +71,8 @@ export class RabbitMqSubscriber {
 
     protected getQueueSettings(deadletterExchangeName: string): amqp.Options.AssertQueue {
         return {
-            exclusive: true
+            exclusive: true,
+            autoDelete: true
         }
     }
 


### PR DESCRIPTION
Hello,

As explained in #2 I have noticed that queues are not deleted which causes a huge mess on rabbitMQ if we go to prod. 

This PR sets autoDelete to true so that queues are cleaned correctly.